### PR TITLE
Guard Thomastag signup until opening

### DIFF
--- a/src/app/events/thomastag-2025/page.tsx
+++ b/src/app/events/thomastag-2025/page.tsx
@@ -1,5 +1,9 @@
 import TallyForm from '@/components/TallyForm';
 import { getEventSignupForm } from '@/lib/tally';
+import {
+  THOMASTAG_SIGNUP_OPENS_TEXT,
+  isThomastagSignupOpen,
+} from '@/lib/thomastag';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
@@ -171,14 +175,21 @@ export default function Thomastag2025Page() {
 
 async function SignupSection() {
   const formId = await getEventSignupForm('Thomastag 2025');
+  const signupOpen = isThomastagSignupOpen();
   return (
     <section className="text-center">
       <h2 className="mb-4 text-2xl font-semibold">Ready to join?</h2>
-      {formId ? (
-        <TallyForm formId={formId} height={600} />
+      {signupOpen ? (
+        formId ? (
+          <TallyForm formId={formId} height={600} />
+        ) : (
+          <p className="text-gray-700 dark:text-gray-300">
+            Signup form unavailable. Please try again later.
+          </p>
+        )
       ) : (
         <p className="text-gray-700 dark:text-gray-300">
-          Signup form unavailable. Please try again later.
+          {`Sign-up opens ${THOMASTAG_SIGNUP_OPENS_TEXT}`}
         </p>
       )}
       <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,8 @@
 import { getEventSignupForm } from '@/lib/tally';
+import {
+  THOMASTAG_SIGNUP_OPENS_TEXT,
+  isThomastagSignupOpen,
+} from '@/lib/thomastag';
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -76,6 +80,7 @@ export default function Home() {
 
 async function ThomastagHero() {
   const formId = await getEventSignupForm('Thomastag 2025');
+  const signupOpen = isThomastagSignupOpen();
   return (
     <section className="bg-gradient-to-r from-blue-700 via-indigo-600 to-purple-700 py-20 text-center text-white">
       <div className="mx-auto max-w-4xl px-8">
@@ -88,19 +93,28 @@ async function ThomastagHero() {
           >
             Event details
           </Link>
-          {formId ? (
-            <Link
-              href={`https://tally.so/r/${formId}`}
-              className="rounded bg-yellow-300 px-6 py-3 font-semibold text-gray-900 hover:bg-yellow-400"
-            >
-              Sign up now
-            </Link>
+          {signupOpen ? (
+            formId ? (
+              <Link
+                href={`https://tally.so/r/${formId}`}
+                className="rounded bg-yellow-300 px-6 py-3 font-semibold text-gray-900 hover:bg-yellow-400"
+              >
+                Sign up now
+              </Link>
+            ) : (
+              <button
+                disabled
+                className="cursor-not-allowed rounded bg-white/30 px-6 py-3 font-semibold text-white opacity-80"
+              >
+                Signup form unavailable. Please try again later.
+              </button>
+            )
           ) : (
             <button
               disabled
               className="cursor-not-allowed rounded bg-white/30 px-6 py-3 font-semibold text-white opacity-80"
             >
-              Sign-up opens 22 August 2025
+              {`Sign-up opens ${THOMASTAG_SIGNUP_OPENS_TEXT}`}
             </button>
           )}
         </div>

--- a/src/lib/thomastag.ts
+++ b/src/lib/thomastag.ts
@@ -1,0 +1,8 @@
+export const THOMASTAG_SIGNUP_OPENS = new Date('2025-08-22T09:00:00Z');
+
+export function isThomastagSignupOpen(now: Date = new Date()): boolean {
+  return now.getTime() >= THOMASTAG_SIGNUP_OPENS.getTime();
+}
+
+export const THOMASTAG_SIGNUP_OPENS_TEXT =
+  '22 August 2025 at 12:00 (UTC+3)';


### PR DESCRIPTION
## Summary
- add helpers describing Thomastag signup opening time
- hide signup form and link until 22 August 2025 12:00 UTC+3

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed954c908324bde94d6bac56777d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Signup availability now updates automatically based on the official opening time.
  - Home and Thomastag 2025 pages reflect real-time status:
    - If open and form available: shows the active “Sign up now” action/form.
    - If open but form unavailable: shows a disabled state with “Signup form unavailable. Please try again later.”
    - If not yet open: shows a disabled state with a dynamic “Sign-up opens [date/time]” message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->