### PR TITLE
feat: hide membership features via env flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Tally API token for creating forms
 TALLY_API=
+# Set to true to hide membership join features
+NEXT_PUBLIC_HIDE_MEMBERSHIP=

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,6 +1,7 @@
 import TallyForm from '@/components/TallyForm';
 import { getMembershipForm } from '@/lib/tally';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 export const metadata: Metadata = {
   title: 'Join',
@@ -9,6 +10,10 @@ export const metadata: Metadata = {
 };
 
 export default async function JoinPage() {
+  if (process.env.NEXT_PUBLIC_HIDE_MEMBERSHIP === 'true') {
+    notFound();
+  }
+
   const formId = await getMembershipForm();
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,7 @@ const organizationLd = {
 };
 
 export default function Home() {
+  const hideMembership = process.env.NEXT_PUBLIC_HIDE_MEMBERSHIP === 'true';
   return (
     <>
       <Script
@@ -59,16 +60,18 @@ export default function Home() {
             .
           </p>
         </section>
-        <section>
-          <h2 className="mb-2 text-2xl font-semibold">Community</h2>
-          <p className="text-gray-700 dark:text-gray-300">
-            Connect with fellow enjoyers and share your passion for academic
-            culture and tradition.
-          </p>
-          <Link href="/join" className="text-blue-600 hover:underline">
-            Apply for membership
-          </Link>
-        </section>
+        {!hideMembership && (
+          <section>
+            <h2 className="mb-2 text-2xl font-semibold">Community</h2>
+            <p className="text-gray-700 dark:text-gray-300">
+              Connect with fellow enjoyers and share your passion for academic
+              culture and tradition.
+            </p>
+            <Link href="/join" className="text-blue-600 hover:underline">
+              Apply for membership
+            </Link>
+          </section>
+        )}
       </main>
     </>
   );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,7 +6,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     '',
     '/events',
     '/events/thomastag-2025',
-    '/join',
+    ...(process.env.NEXT_PUBLIC_HIDE_MEMBERSHIP === 'true' ? [] : ['/join']),
     '/privacy',
   ].map((route) => ({
     url: `${baseUrl}${route}`,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,10 +3,12 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
+const hideMembership = process.env.NEXT_PUBLIC_HIDE_MEMBERSHIP === 'true';
+
 const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/events/thomastag-2025', label: 'Events' },
-  { href: '/join', label: 'Join' },
+  ...(hideMembership ? [] : [{ href: '/join', label: 'Join' }]),
 ];
 
 export default function Header() {


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_HIDE_MEMBERSHIP` env flag to disable joining features
- hide navigation link and homepage community section when flag enabled
- return 404 for /join and omit from sitemap when membership disabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1ee139c14832499aa916eb4012048