### PR TITLE
feat: enable Thomastag signups

### DIFF
--- a/src/app/events/thomastag-2025/page.tsx
+++ b/src/app/events/thomastag-2025/page.tsx
@@ -136,7 +136,17 @@ export default function Thomastag2025Page() {
         </HeroVideoWithModal>
       </section>
 
-  <section className="mb-8 px-4 md:px-8">
+      {/* Top call-to-action */}
+      <section className="mb-8 px-4 md:px-8 flex justify-center">
+        <Link
+          href="https://signup.academicculture.org/events/thomastag-2025"
+          className="rounded bg-yellow-300 px-6 py-3 font-semibold text-gray-900 hover:bg-yellow-400"
+        >
+          {`Sign up here, opens ${THOMASTAG_SIGNUP_OPENS_TEXT}`}
+        </Link>
+      </section>
+
+      <section className="mb-8 px-4 md:px-8">
         <h2 className="mb-2 text-2xl font-semibold">What is Thomastag?</h2>
         <p className="text-gray-700 dark:text-gray-300">
           Thomastag is the German holiday that marks the shortest day of the

--- a/src/app/events/thomastag-2025/page.tsx
+++ b/src/app/events/thomastag-2025/page.tsx
@@ -1,11 +1,8 @@
 import ClientImageWithCarousel from '@/components/ClientImageWithCarousel';
 import HeroVideoWithModal from '@/components/HeroVideoWithModal';
-import TallyForm from '@/components/TallyForm';
-import { getEventSignupForm } from '@/lib/tally';
 import {
   THOMASTAG_SIGNUP_CLOSES_TEXT,
   THOMASTAG_SIGNUP_OPENS_TEXT,
-  isThomastagSignupOpen,
 } from '@/lib/thomastag';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -358,25 +355,16 @@ export default function Thomastag2025Page() {
   );
 }
 
-async function SignupSection() {
-  const formId = await getEventSignupForm('Thomastag 2025');
-  const signupOpen = isThomastagSignupOpen();
+function SignupSection() {
   return (
     <section className="text-center">
       <h2 className="mb-4 text-2xl font-semibold">Ready to join?</h2>
-      {signupOpen ? (
-        formId ? (
-          <TallyForm formId={formId} height={600} />
-        ) : (
-          <p className="text-gray-700 dark:text-gray-300">
-            Signup form unavailable. Please try again later.
-          </p>
-        )
-      ) : (
-        <p className="text-gray-700 dark:text-gray-300">
-          {`Sign-up opens ${THOMASTAG_SIGNUP_OPENS_TEXT}`}
-        </p>
-      )}
+      <Link
+        href="https://signup.academicculture.org/events/thomastag-2025"
+        className="rounded bg-yellow-300 px-6 py-3 font-semibold text-gray-900 hover:bg-yellow-400"
+      >
+        {`Sign up here, opens ${THOMASTAG_SIGNUP_OPENS_TEXT}`}
+      </Link>
       <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
         Seats are limited to 30 — first come, first served.
       </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,5 @@
 import HomeHeroImageClient from '@/components/HomeHeroImageClient';
-import { getEventSignupForm } from '@/lib/tally';
-import {
-  THOMASTAG_SIGNUP_OPENS_TEXT,
-  isThomastagSignupOpen,
-} from '@/lib/thomastag';
+import { THOMASTAG_SIGNUP_OPENS_TEXT } from '@/lib/thomastag';
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -84,55 +80,35 @@ export default function Home() {
 
 
 
-async function ThomastagHero() {
-  const formId = await getEventSignupForm('Thomastag 2025');
-  const signupOpen = isThomastagSignupOpen();
-        return (
-          <section className="front-hero-gradient py-20 text-center text-white">
-            <div className="mx-auto max-w-4xl px-8">
-              <HomeHeroImageClient
-                src="https://ik.imagekit.io/tapiiri/ace/AcademicCultureEnjoyers/nuremberg.jpg?tr=w-1800,h-500,c-at_max"
-                alt="City of Nuremberg"
-                width={1800}
-                height={500}
-                crop={true}
-                caption=""
-              />
-              <h2 className="mb-4 text-5xl font-extrabold">Thomastag 2025</h2>
-              <p className="mb-6 text-xl">19–21 December 2025 · Nürnberg, Germany</p>
-              <div className="flex flex-wrap justify-center gap-4">
-                <Link
-                  href="/events/thomastag-2025"
-                  className="rounded bg-white px-6 py-3 font-semibold text-blue-700 hover:bg-gray-100"
-                >
-                  Event details
-                </Link>
-                {signupOpen ? (
-                  formId ? (
-                    <Link
-                      href={`https://tally.so/r/${formId}`}
-                      className="rounded bg-yellow-300 px-6 py-3 font-semibold text-gray-900 hover:bg-yellow-400"
-                    >
-                      Sign up now
-                    </Link>
-                  ) : (
-                    <button
-                      disabled
-                      className="cursor-not-allowed rounded bg-white/30 px-6 py-3 font-semibold text-white opacity-80"
-                    >
-                      Signup form unavailable. Please try again later.
-                    </button>
-                  )
-                ) : (
-                  <button
-                    disabled
-                    className="cursor-not-allowed rounded bg-white/30 px-6 py-3 font-semibold text-white opacity-80"
-                  >
-                    {`Sign-up opens ${THOMASTAG_SIGNUP_OPENS_TEXT}`}
-                  </button>
-                )}
-              </div>
-            </div>
-          </section>
-        );
+function ThomastagHero() {
+  return (
+    <section className="front-hero-gradient py-20 text-center text-white">
+      <div className="mx-auto max-w-4xl px-8">
+        <HomeHeroImageClient
+          src="https://ik.imagekit.io/tapiiri/ace/AcademicCultureEnjoyers/nuremberg.jpg?tr=w-1800,h-500,c-at_max"
+          alt="City of Nuremberg"
+          width={1800}
+          height={500}
+          crop={true}
+          caption=""
+        />
+        <h2 className="mb-4 text-5xl font-extrabold">Thomastag 2025</h2>
+        <p className="mb-6 text-xl">19–21 December 2025 · Nürnberg, Germany</p>
+        <div className="flex flex-wrap justify-center gap-4">
+          <Link
+            href="/events/thomastag-2025"
+            className="rounded bg-white px-6 py-3 font-semibold text-blue-700 hover:bg-gray-100"
+          >
+            Event details
+          </Link>
+          <Link
+            href="https://signup.academicculture.org/events/thomastag-2025"
+            className="rounded bg-yellow-300 px-6 py-3 font-semibold text-gray-900 hover:bg-yellow-400"
+          >
+            {`Sign up here, opens ${THOMASTAG_SIGNUP_OPENS_TEXT}`}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/src/lib/thomastag.ts
+++ b/src/lib/thomastag.ts
@@ -1,12 +1,2 @@
-export const THOMASTAG_SIGNUP_OPENS = new Date('2025-08-23T09:00:00Z');
-export const THOMASTAG_SIGNUP_CLOSES = new Date('2025-08-31T20:59:00Z');
-
-export function isThomastagSignupOpen(now: Date = new Date()): boolean {
-  return (
-    now.getTime() >= THOMASTAG_SIGNUP_OPENS.getTime() &&
-    now.getTime() <= THOMASTAG_SIGNUP_CLOSES.getTime()
-  );
-}
-
 export const THOMASTAG_SIGNUP_OPENS_TEXT = '23 August 2025 at 12:00 (UTC+3)';
 export const THOMASTAG_SIGNUP_CLOSES_TEXT = '31 August 2025 at 23:59 (UTC+3)';


### PR DESCRIPTION
## Summary
- Replace Thomastag signup button with new signup portal link
- Remove date gating and show signup start date next to active button
- Simplify Thomastag helper to only export signup date text
- Embed signup opening date directly into hero and event signup buttons for brevity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d3c03e7c83249431b0f4bcea0797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thomastag 2025: Replaced the embedded signup form with a single external “Sign up” button linking to signup.academicculture.org/events/thomastag-2025; the button is always visible and displays the opening date text.
  * Homepage hero updated to use the same external signup link for Thomastag 2025.
  * Added a brief privacy notice in the signup section with a link to the Privacy page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->