### PR TITLE
Add /calendar redirect, CALENDAR_URL env, and Calendar nav link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 TALLY_API=
 # Set to true to hide membership join features
 NEXT_PUBLIC_HIDE_MEMBERSHIP=
+
+# Server-side Google Calendar URL redirect target for /calendar
+CALENDAR_URL=

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,19 @@
 import type { NextConfig } from 'next';
 
+const defaultCalendarUrl =
+	'https://calendar.google.com/calendar/u/0?cid=YTI1NWJiM2QyYjU3MWI0NmIyNTY5YTFlMzhiYjJiOWJkNGU3MTBiOTllYzZiMzcyMTdiY2JlZjlkMjE0MTllZkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t';
+
 const nextConfig: NextConfig = {
+	async redirects() {
+		return [
+			{
+				source: '/calendar',
+				destination:
+					process.env.CALENDAR_URL || process.env.NEXT_PUBLIC_CALENDAR_URL || defaultCalendarUrl,
+				permanent: true,
+			},
+		];
+	},
 	images: {
 		remotePatterns: [
 			{

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,10 +4,10 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 const hideMembership = process.env.NEXT_PUBLIC_HIDE_MEMBERSHIP === 'true';
-
 const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/events/thomastag-2025', label: 'Events' },
+  { href: '/calendar', label: 'Calendar' },
   ...(hideMembership ? [] : [{ href: '/join', label: 'Join' }]),
 ];
 


### PR DESCRIPTION
### Motivation

- Provide a server-side redirect for `/calendar` to a configurable Google Calendar URL.  
- Allow deployments to override the default calendar target by exposing `CALENDAR_URL` in the example env file.  
- Surface a direct "Calendar" link in the site header for easier navigation.

### Description

- Add `defaultCalendarUrl` and an `async redirects()` in `next.config.ts` that redirects `/calendar` to `process.env.CALENDAR_URL || process.env.NEXT_PUBLIC_CALENDAR_URL || defaultCalendarUrl`.  
- Add `CALENDAR_URL` to `.env.example`.  
- Add a `{ href: '/calendar', label: 'Calendar' }` entry to the navigation links in `src/components/Header.tsx`.

### Testing

- Ran TypeScript type-check and `next build`, and both completed successfully.  
- No automated unit tests were modified or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b72f9a388324810274d0ad86d46d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Calendar link to the header navigation menu for quick access.
  * Implemented automatic redirection for the calendar route using configurable environment settings with a default fallback option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->