### PR TITLE
Restructure events listings for spring 2026

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,25 +1,124 @@
+import { pastEvents, upcomingEvents } from '@/lib/events';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Events',
-  description: 'Explore upcoming events from Academic Culture Enjoyers.',
+  description:
+    'Explore upcoming and past Academic Culture Enjoyers events across Europe.',
 };
+
+function EventCard({
+  title,
+  subtitle,
+  dateLabel,
+  location,
+  description,
+  highlights,
+  ctaLabel,
+  ctaHref,
+  status,
+}: {
+  title: string;
+  subtitle: string;
+  dateLabel: string;
+  location: string;
+  description: string;
+  highlights: string[];
+  ctaLabel?: string;
+  ctaHref?: string;
+  status?: string;
+}) {
+  return (
+    <article className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold tracking-wide text-blue-700 uppercase dark:text-blue-400">
+            {dateLabel}
+          </p>
+          <h2 className="mt-1 text-2xl font-bold">{title}</h2>
+          <p className="text-base text-gray-600 dark:text-gray-300">
+            {subtitle}
+          </p>
+        </div>
+        <span className="rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-200">
+          {location}
+        </span>
+      </div>
+      <p className="text-gray-700 dark:text-gray-300">{description}</p>
+      <ul className="mt-4 list-disc space-y-2 pl-5 text-gray-700 dark:text-gray-300">
+        {highlights.map((highlight) => (
+          <li key={highlight}>{highlight}</li>
+        ))}
+      </ul>
+      {(ctaHref || status) && (
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          {ctaHref && ctaLabel ? (
+            <Link
+              href={ctaHref}
+              className="rounded bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700"
+            >
+              {ctaLabel}
+            </Link>
+          ) : null}
+          {status ? (
+            <p className="text-sm text-gray-600 dark:text-gray-400">{status}</p>
+          ) : null}
+        </div>
+      )}
+    </article>
+  );
+}
 
 export default function EventsPage() {
   return (
-    <main className="mx-auto max-w-3xl p-8">
-      <h1 className="mb-6 text-3xl font-bold">Events</h1>
-      <ul className="list-disc pl-6 text-gray-700 dark:text-gray-300">
-        <li>
-          <Link
-            href="/events/thomastag-2025"
-            className="text-blue-600 hover:underline"
-          >
-            Thomastag 2025 – Southern German Traditions Weekend
-          </Link>
-        </li>
-      </ul>
+    <main className="mx-auto max-w-5xl p-8">
+      <section className="mb-12">
+        <p className="text-sm font-semibold tracking-wide text-blue-700 uppercase dark:text-blue-400">
+          Academic Culture Enjoyers
+        </p>
+        <h1 className="mt-2 mb-4 text-4xl font-bold">Events</h1>
+        <p className="max-w-3xl text-lg text-gray-700 dark:text-gray-300">
+          Join ACE events across Europe, from spring sitsit gatherings to major
+          tradition weekends. Here you can find our current upcoming events as
+          well as selected past events.
+        </p>
+      </section>
+
+      <section aria-labelledby="upcoming-events" className="mb-14">
+        <div className="mb-6 flex items-end justify-between gap-4">
+          <div>
+            <h2 id="upcoming-events" className="text-3xl font-semibold">
+              Upcoming events
+            </h2>
+            <p className="mt-2 text-gray-700 dark:text-gray-300">
+              Save the dates for spring 2026 and keep an eye out for signup
+              details.
+            </p>
+          </div>
+        </div>
+        <div className="grid gap-6">
+          {upcomingEvents.map((event) => (
+            <EventCard key={`${event.title}-${event.dateLabel}`} {...event} />
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="past-events">
+        <div className="mb-6">
+          <h2 id="past-events" className="text-3xl font-semibold">
+            Past events
+          </h2>
+          <p className="mt-2 text-gray-700 dark:text-gray-300">
+            Looking for previous ACE gatherings? Browse our archive here.
+          </p>
+        </div>
+        <div className="grid gap-6">
+          {pastEvents.map((event) => (
+            <EventCard key={`${event.title}-${event.dateLabel}`} {...event} />
+          ))}
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,5 @@
 import HomeHeroImageClient from '@/components/HomeHeroImageClient';
-import {
-  THOMASTAG_SIGNUP_IS_OPEN,
-  THOMASTAG_SIGNUP_OPENS_TEXT,
-  THOMASTAG_SIGNUP_STATUS_TEXT,
-} from '@/lib/thomastag';
+import { upcomingEvents } from '@/lib/events';
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -40,7 +36,7 @@ export default function Home() {
         strategy="beforeInteractive"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
       />
-      <ThomastagHero />
+      <UpcomingEventsHero />
       <main className="mx-auto max-w-4xl p-8">
         <Image
           src="/globe.svg"
@@ -82,41 +78,42 @@ export default function Home() {
   );
 }
 
+function UpcomingEventsHero() {
+  const nextEventTitles = upcomingEvents
+    .map((event) => event.title)
+    .join(' · ');
 
-
-function ThomastagHero() {
   return (
     <section className="front-hero-gradient py-20 text-center text-white">
       <div className="mx-auto max-w-4xl px-8">
         <HomeHeroImageClient
           src="https://ik.imagekit.io/tapiiri/ace/AcademicCultureEnjoyers/nuremberg.jpg?tr=w-1800,h-500,c-at_max"
-          alt="City of Nuremberg"
+          alt="Academic Culture Enjoyers events across Europe"
           width={1800}
           height={500}
           crop={true}
           caption=""
         />
-        <h2 className="mb-4 text-5xl font-extrabold">Thomastag 2025</h2>
-        <p className="mb-6 text-xl">19–21 December 2025 · Nürnberg, Germany</p>
+        <h2 className="mb-4 text-5xl font-extrabold">
+          Spring 2026 events are here
+        </h2>
+        <p className="mb-3 text-xl">
+          ACE Wappusitsit · EuroSitsit Aachen · EuroSitsit Lausanne
+        </p>
+        <p className="mb-6 text-lg text-blue-50">
+          Save the dates for April and May 2026 and check the events page for
+          the latest details.
+        </p>
         <div className="flex flex-wrap justify-center gap-4">
           <Link
-            href="/events/thomastag-2025"
+            href="/events"
             className="rounded bg-white px-6 py-3 font-semibold text-blue-700 hover:bg-gray-100"
           >
-            Event details
+            Explore events
           </Link>
-          {THOMASTAG_SIGNUP_IS_OPEN ? (
-            <Link
-              href="https://signup.academicculture.org/events/thomastag-2025"
-              className="rounded bg-yellow-300 px-6 py-3 font-semibold text-gray-900 hover:bg-yellow-400"
-            >
-              {`Sign up here, opens ${THOMASTAG_SIGNUP_OPENS_TEXT}`}
-            </Link>
-          ) : (
-            <span className="rounded bg-gray-200 px-6 py-3 font-semibold text-gray-700">
-              {THOMASTAG_SIGNUP_STATUS_TEXT}
-            </span>
-          )}
+          <span className="rounded bg-blue-900/40 px-6 py-3 font-semibold text-blue-50">
+            {nextEventTitles}
+          </span>
         </div>
       </div>
     </section>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 const hideMembership = process.env.NEXT_PUBLIC_HIDE_MEMBERSHIP === 'true';
 const navLinks = [
   { href: '/', label: 'Home' },
-  { href: '/events/thomastag-2025', label: 'Events' },
+  { href: '/events', label: 'Events' },
   { href: '/calendar', label: 'Calendar' },
   ...(hideMembership ? [] : [{ href: '/join', label: 'Join' }]),
 ];
@@ -15,7 +15,7 @@ export default function Header() {
   const pathname = usePathname();
 
   return (
-  <header className="z-30 relative border-b bg-white text-gray-700 shadow-md dark:bg-gray-900 dark:text-gray-300">
+    <header className="relative z-30 border-b bg-white text-gray-700 shadow-md dark:bg-gray-900 dark:text-gray-300">
       <a href="#content" className="sr-only focus:not-sr-only">
         Skip to main content
       </a>

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -15,7 +15,7 @@ export const upcomingEvents: EventCard[] = [
   {
     title: 'ACE Wappusitsit',
     subtitle: 'Celebrate Wappu together at Aalto University',
-    dateLabel: 'Monday, April 28, 2026 · 18:00',
+    dateLabel: 'Tuesday, April 28, 2026 · 18:00',
     location: 'Espoo, Finland',
     description:
       'Celebrate European student culture and friendship at ACE Wappusitsit on the Aalto University campus. International guests from across Europe will join for an evening of good food, drinks, songs, and excellent company, followed by an afterparty that continues late into the night.',

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,79 @@
+export type EventCard = {
+  slug?: string;
+  title: string;
+  subtitle: string;
+  dateLabel: string;
+  location: string;
+  description: string;
+  highlights: string[];
+  ctaLabel?: string;
+  ctaHref?: string;
+  status?: string;
+};
+
+export const upcomingEvents: EventCard[] = [
+  {
+    title: 'ACE Wappusitsit',
+    subtitle: 'Celebrate Wappu together at Aalto University',
+    dateLabel: 'Monday, April 28, 2026 · 18:00',
+    location: 'Espoo, Finland',
+    description:
+      'Celebrate European student culture and friendship at ACE Wappusitsit on the Aalto University campus. International guests from across Europe will join for an evening of good food, drinks, songs, and excellent company, followed by an afterparty that continues late into the night.',
+    highlights: [
+      'Sitsit at Otakaari 20 upstairs, afterparty at Otakaari 20 downstairs',
+      'Dress code: formal with academic accessories',
+      'Price: €30, or €25 alcohol-free',
+      'You can also join the organizing crew through the same signup form',
+    ],
+    status: 'Signup and event details coming soon.',
+  },
+  {
+    title: 'ACE EuroSitsit Aachen',
+    subtitle: 'A spring EuroSitsit in Westpark house spirit',
+    dateLabel: 'Saturday, May 9, 2026',
+    location: 'Aachen, Germany',
+    description:
+      'ACE EuroSitsit Aachen brings together academic culture enjoyers for an intimate spring sitsit in Aachen. Expect warm hospitality, a festive international atmosphere, good food, student songs, and a close-knit table setting designed for around 30 to 40 participants.',
+    highlights: [
+      'Planned venue: Westpark house',
+      'Target capacity: 30–40 participants',
+      'Preliminary ticket price target: around €20',
+      'If interest exceeds capacity, the organizers will look into a bigger venue',
+    ],
+    status: 'Venue, signup, and final pricing details will be confirmed soon.',
+  },
+  {
+    title: 'ACE EuroSitsit Lausanne',
+    subtitle: 'An international evening of songs, traditions, and friendship',
+    dateLabel: 'Saturday, May 23, 2026',
+    location: 'Lausanne, Switzerland',
+    description:
+      'ACE EuroSitsit Lausanne continues the spring series with a celebration of European student culture in Lausanne. Join fellow guests from across Europe for a festive evening built around shared traditions, a welcoming international crowd, and the unmistakable atmosphere of a great sitsit.',
+    highlights: [
+      'International guests from across Europe',
+      'Student songs, shared traditions, and a festive dinner setting',
+      'A great chance to meet the ACE community in Switzerland',
+      'More practical details and signup information will follow',
+    ],
+    status: 'Full program and signup information are on the way.',
+  },
+];
+
+export const pastEvents: EventCard[] = [
+  {
+    slug: '/events/thomastag-2025',
+    title: 'Thomastag 2025',
+    subtitle: 'Southern German Traditions Weekend',
+    dateLabel: 'December 19–21, 2025',
+    location: 'Nürnberg, Germany',
+    description:
+      'A weekend in Nürnberg focused on Southern German student traditions, including a Kommers, fraternity visits, and the Thomastag celebrations with local hosts and partners.',
+    highlights: [
+      'Hosted with Onoldia and the Schwarzburgbund',
+      'Included a city tour, Kommers, and Thomasbummel traditions',
+      'Event page remains available with the full program and background information',
+    ],
+    ctaLabel: 'View event page',
+    ctaHref: '/events/thomastag-2025',
+  },
+];


### PR DESCRIPTION
### Motivation

- Provide a clear upcoming events listing for spring 2026 (ACE Wappusitsit, ACE EuroSitsit Aachen, ACE EuroSitsit Lausanne) while keeping past events archived separately. 
- Make the site navigation and home hero point to a central events index instead of a single event page so visitors can discover all events. 

### Description

- Add a shared events data module at `src/lib/events.ts` containing `upcomingEvents` (three spring 2026 events) and `pastEvents` (Thomastag 2025) as typed `EventCard` records. 
- Replace the simple list on the events index with a card-based layout at `src/app/events/page.tsx` that renders `upcomingEvents` and `pastEvents` sections using a local `EventCard` renderer. 
- Update the site header at `src/components/Header.tsx` so the top-level “Events” nav item links to `/events` (the new index) instead of the Thomastag page. 
- Update the home hero at `src/app/page.tsx` to an `UpcomingEventsHero` that highlights the spring events and links to `/events`, and wire the hero text to `upcomingEvents`. 
- Run formatting (`prettier`) and small stylistic cleanups across a few components to keep code style consistent. 

### Testing

- Ran `npm run lint`, which completed successfully but reported a pre-existing `@next/next/no-img-element` warning in `src/components/ClientImageWithModal.tsx`. 
- Ran `npm run build`, which completed successfully and generated the static routes for `/`, `/events`, `/events/thomastag-2025`, and related pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfeb2df2e88324821c93f707f8e48d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events page now shows separate Upcoming and Past events with richer event cards (date, location, description, highlights, CTAs/status).
  * Homepage includes a new upcoming-events hero with a CTA to explore events.

* **Improvements**
  * Navigation updated to link to the consolidated events listing for easier access.
  * Page metadata and hero text refined to reference upcoming and past events across Europe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->